### PR TITLE
Feature: adjustable interval between elements

### DIFF
--- a/lib/src/intersperse.dart
+++ b/lib/src/intersperse.dart
@@ -5,14 +5,17 @@
 ///     final list1 = intersperse(2, <int>[]); // [];
 ///     final list2 = intersperse(2, [0]); // [0];
 ///     final list3 = intersperse(2, [0, 0]); // [0, 2, 0];
+///     final list4 = intersperse(2, [0, 0, 0, 0, 0, 0], interval: 2); // [0, 0, 2, 0, 0, 2, 0, 0];
 ///
-Iterable<T> intersperse<T>(T element, Iterable<T> iterable) sync* {
+Iterable<T> intersperse<T>(T element, Iterable<T> iterable, {int interval = 1}) sync* {
   final iterator = iterable.iterator;
   if (iterator.moveNext()) {
     yield iterator.current;
+    int x = 1;
     while (iterator.moveNext()) {
-      yield element;
+      if (x % interval == 0) yield element;
       yield iterator.current;
+      x++;
     }
   }
 }

--- a/lib/src/intersperse_extensions.dart
+++ b/lib/src/intersperse_extensions.dart
@@ -8,9 +8,10 @@ extension IntersperseExtensions<T> on Iterable<T> {
   ///     final list1 = <int>[].intersperse(2); // [];
   ///     final list2 = [0].intersperse(2); // [0];
   ///     final list3 = [0, 0].intersperse(2); // [0, 2, 0];
+  ///     final list4 = [0, 0, 0, 0, 0, 0].intersperse(2, interval: 2); // [0, 0, 2, 0, 0, 2, 0, 0];
   ///
-  Iterable<T> intersperse(T element) {
-    return core.intersperse(element, this);
+  Iterable<T> intersperse(T element, {int interval = 1}) {
+    return core.intersperse(element, this, interval: interval);
   }
 
   /// Puts [element] between every element in [list] and at the bounds of [list].

--- a/test/extensions_test.dart
+++ b/test/extensions_test.dart
@@ -22,9 +22,20 @@ void main() {
       );
     });
     test("is lazy", () {
-      final Iterable<int> sut =
-          List.generate(1000000, (a) => a).intersperse(-1);
+      final Iterable<int> sut = List.generate(1000000, (a) => a).intersperse(-1);
       expect(0, sut.first);
+    });
+    test('interval-2', () {
+      expect(
+        <int>[0, 0, 0, 0, 0, 0].intersperse(-1, interval: 2),
+        <int>[0, 0, -1, 0, 0, -1, 0, 0],
+      );
+    });
+    test('interval-3', () {
+      expect(
+        <int>[0, 0, 0, 0, 0, 0].intersperse(-1, interval: 3),
+        <int>[0, 0, 0, -1, 0, 0, 0],
+      );
     });
   });
 
@@ -39,12 +50,10 @@ void main() {
       expect(<int>[1, 2].intersperseOuter(-1), <int>[-1, 1, -1, 2, -1]);
     });
     test("3", () {
-      expect(
-          <int>[1, 2, 3].intersperseOuter(-1), <int>[-1, 1, -1, 2, -1, 3, -1]);
+      expect(<int>[1, 2, 3].intersperseOuter(-1), <int>[-1, 1, -1, 2, -1, 3, -1]);
     });
     test("is lazy", () {
-      final Iterable<int> sut =
-          List.generate(1000000, (a) => a).intersperseOuter(-1);
+      final Iterable<int> sut = List.generate(1000000, (a) => a).intersperseOuter(-1);
       expect(-1, sut.first);
     });
   });

--- a/test/intersperse_test.dart
+++ b/test/intersperse_test.dart
@@ -22,9 +22,20 @@ void main() {
       );
     });
     test("is lazy", () {
-      final Iterable<int> sut =
-          intersperse(-1, List.generate(1000000, (a) => a));
+      final Iterable<int> sut = intersperse(-1, List.generate(1000000, (a) => a));
       expect(0, sut.first);
+    });
+    test('interval-2', () {
+      expect(
+        intersperse(-1, <int>[0, 0, 0, 0, 0, 0], interval: 2),
+        <int>[0, 0, -1, 0, 0, -1, 0, 0],
+      );
+    });
+    test('interval-3', () {
+      expect(
+        intersperse(-1, <int>[0, 0, 0, 0, 0, 0], interval: 3),
+        <int>[0, 0, 0, -1, 0, 0, 0],
+      );
     });
   });
 
@@ -39,12 +50,10 @@ void main() {
       expect(intersperseOuter(-1, <int>[1, 2]), <int>[-1, 1, -1, 2, -1]);
     });
     test("3", () {
-      expect(
-          intersperseOuter(-1, <int>[1, 2, 3]), <int>[-1, 1, -1, 2, -1, 3, -1]);
+      expect(intersperseOuter(-1, <int>[1, 2, 3]), <int>[-1, 1, -1, 2, -1, 3, -1]);
     });
     test("is lazy", () {
-      final Iterable<int> sut =
-          intersperseOuter(-1, List.generate(1000000, (a) => a));
+      final Iterable<int> sut = intersperseOuter(-1, List.generate(1000000, (a) => a));
       expect(-1, sut.first);
     });
   });


### PR DESCRIPTION
I needed this functionality for one of my projects so I added it. Made a PR because I thought you might want it in the main repo.
I added `interval` as a named parameter to the `intersperse` function (and extension method).
It does this: `intersperse(2, [0, 0, 0, 0, 0, 0], interval: 2); // [0, 0, 2, 0, 0, 2, 0, 0];`


Also an unrelated note just in case you didn't know: on the [pub.dev page](https://pub.dev/packages/intersperse) it doesn't list the github repo for this package.